### PR TITLE
Switch to metric by default and deal with empty ele in GPX files

### DIFF
--- a/gpxtools.lisp
+++ b/gpxtools.lisp
@@ -9,9 +9,11 @@
   (* (/ 1.0 1609.344) val))
 
 (defun string-to-float (str)
-  (with-input-from-string
+  (if (string/= str "")
+   (with-input-from-string
    (in str)
-   (coerce (read in) 'double-float)))
+     (coerce (read in) 'double-float))
+   0.0d0)) ; If string is empty, just return zero.
 
 (defgeneric to-vec3 (pt))
 

--- a/gpxtools.lisp
+++ b/gpxtools.lisp
@@ -226,21 +226,37 @@
         (el (elevation-loss gpx))
         (dist (distance gpx))
         (shortunit (if (eq units 'imperial) "feet" "meters"))
-        (longunit (if (eq units 'imperial) "miles" "kilometers")))
+        (longunit (if (eq units 'imperial) "miles" "kilometers"))
+	(start-end-time (time-range gpx)))
     (list 
      (list 'total-elevation-gain (if (eq units 'imperial) (meters-to-feet eg) eg) shortunit)
      (list 'total-elevation-lost (if (eq units 'imperial) (meters-to-feet el) el) shortunit)
-     (list 'total-distance (if (eq units 'imperial) (meters-to-miles dist) (/ dist 1000.0)) longunit))))
+     (list 'total-distance (if (eq units 'imperial) (meters-to-miles dist) (/ dist 1000.0)) longunit)
+     (list 'start-time (first start-end-time))
+     (list 'end-time (car (last start-end-time))))))
 
 (defun summarize (gpx &key (units 'metric))
   (let ((eg (elevation-gain gpx))
         (el (elevation-loss gpx))
         (dist (distance gpx))
         (shortunit (if (eq units 'imperial) "feet" "meters"))
-        (longunit (if (eq units 'imperial) "miles" "kilometers")))
+        (longunit (if (eq units 'imperial) "miles" "kilometers"))
+	(start-end-time (time-range gpx)))
   (format t "Total elevation gain: ~a ~a~%" (if (eq units 'imperial) (meters-to-feet eg) eg) shortunit)
   (format t "Total elevation loss: ~a ~a~%" (if (eq units 'imperial) (meters-to-feet el) el) shortunit)
-  (format t "Total distance:       ~a ~a~%" (if (eq units 'imperial) (meters-to-miles dist) (/ dist 1000.0)) longunit)))
+  (format t "Total distance:       ~a ~a~%" (if (eq units 'imperial) (meters-to-miles dist) (/ dist 1000.0)) longunit)
+  (format t "Start time:        ~a~%" (first start-end-time))
+  (format t "End time:        ~a~%" (car (last start-end-time)))))
+
+(defun time-range (gpx)
+  "Returns a two-member list consisting of the earliest timestamp
+   and the last timestamp in the GPX file"
+  (let ((all-pts (collect-points gpx))
+	(timepoints ()))
+    (loop for i in all-pts
+	  do (push (gpx-pt-time i) timepoints))
+    (let ((sortedtimes (sort timepoints #'string-lessp)))
+      (list (first sortedtimes) (car (last sortedtimes))))))
 
 (defun elevation-plot (gpx &key (file-name))
   (let ((all-pts (collect-points gpx))

--- a/gpxtools.lisp
+++ b/gpxtools.lisp
@@ -219,7 +219,7 @@
 (defun distance (el)
   (traverse2 el #'distance-between))
 
-(defun get-summary (gpx &key (units 'imperial))
+(defun get-summary (gpx &key (units 'metric))
   (let ((eg (elevation-gain gpx))
         (el (elevation-loss gpx))
         (dist (distance gpx))
@@ -230,7 +230,7 @@
      (list 'total-elevation-lost (if (eq units 'imperial) (meters-to-feet el) el) shortunit)
      (list 'total-distance (if (eq units 'imperial) (meters-to-miles dist) (/ dist 1000.0)) longunit))))
 
-(defun summarize (gpx &key (units 'imperial))
+(defun summarize (gpx &key (units 'metric))
   (let ((eg (elevation-gain gpx))
         (el (elevation-loss gpx))
         (dist (distance gpx))


### PR DESCRIPTION
I want to begin extending this library a little bit. My first edit has been making functions use metric units by default, and reserving use of imperial units for those who specifically ask for them. I am used to working in international communities like OpenStreetMap where this is standard.

My second edit fixes a bug in the original jl2/gpxtools version. When the `read-gpx` function parses the GPX file for the `ele` element, it then passes the resulting value to the `string-to-float` function. However, GPX files do not have to contain elevation information at all; for example, GPX files output by a routing engine may lack `ele` if the routing engine is not elevation-aware:

```
    <trkseg>
      <trkpt lon="21.400516" lat="40.781659"></trkpt>
      <trkpt lon="21.400243" lat="40.781569"></trkpt>
      <trkpt lon="21.400053" lat="40.781498"></trkpt>
      <trkpt lon="21.398979" lat="40.781100"></trkpt>
     [...]
```

In the original version, the `string-to-float` function produced an error if the input string was empty. My changed version checks first for whether the string is empty, and if it is, it simply returns `0.0`.

I am new to both Common Lisp and collaborative development on Github, so please excuse any ignorance or breaches of etiquette here.